### PR TITLE
Add support for child loggers

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ const proto = {
   warn: noop,
   info: noop,
   debug: noop,
-  trace: noop
+  trace: noop,
+  child: () => proto
 }
 
 Object.defineProperty(module, 'exports', {

--- a/test.js
+++ b/test.js
@@ -15,3 +15,10 @@ assert.equal(result1, undefined)
 
 const result2 = two.info()
 assert.equal(result2, 'info')
+
+assert.ok(one.child)
+assert.equal(Function.prototype.isPrototypeOf(one.child), true)
+
+const three = two.child()
+assert.ok(three.info)
+assert.equal(Function.prototype.isPrototypeOf(three.info), true)


### PR DESCRIPTION
Some Log4j compatible logger like Bunyan or Pino support child loggers: https://github.com/pinojs/pino/blob/HEAD/docs/child-loggers.md 

This PR adds a `child()` methods that returns another logger. This enables `abstract-logging` to mock loggers in existing projects (which use child loggers).